### PR TITLE
fix link to Spectacle tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Spectacle core API is available in the [Spectacle Docs](https://github.com/F
 
 ## Tutorial
 
-If want you a step-by-step guide for getting started with Spectacle, a basic tutorial is available [here](https://github.com/FormidableLabs/spectacle/blob/master/docs/tutorial.md).
+If want you a step-by-step guide for getting started with Spectacle, a basic tutorial is available [here](https://github.com/FormidableLabs/spectacle/blob/master/docs/content/getting-started.md).
 
 ## Build & Deployment
 


### PR DESCRIPTION
`docs/tutorial.md` has been moved in `master` of Spectacle repo to another location in this commit 
```
commit 4de310ce5b48ce6a2f701470a3edaaa7b712644b
Author: Kylie Stewart <kylie.stewart@formidable.com>
Date:   Wed Jan 8 15:35:11 2020 -0700

    Add react-static content for deploying docs (#786)
```
This pull request fixes link to the page in local `README.MD`